### PR TITLE
利用停止になっているブロックチェーンエクスプローラー(なむやん氏管理)を削除

### DIFF
--- a/links-info.407293983014912010.md
+++ b/links-info.407293983014912010.md
@@ -26,7 +26,6 @@ https://discord.gg/xmWd3yy
 [ブロックチェーン エクスプローラー]  
 - <https://insight.bitzeny.jp/>  
 - <https://zenyinsight.tomotomo9696.xyz/>  
-- <http://namuyan.dip.jp/MultiLightBlockExplorer/index.php?page=selectcoin&coin=zeny>  
 - <https://zeny.insight.monaco-ex.org/>  
 - <https://zny.blockbook.ovh/>
 - <https://zeny.blockbook.zenypota.net/>


### PR DESCRIPTION
なむやんさんのBlockchain Explorerが表ページだと利用停止になっているので。